### PR TITLE
Add type key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import Dropbox from 'dropbox';
 
+const TYPE_KEY = '@@fsType';
+
 /**
  * Convert an object to fs-like stat object
  * 
@@ -76,6 +78,10 @@ export default ({apiKey = null, client = null} = {}) => {
     }
 
     const api = {
+
+        // fs adapter type (for downstream integrations)
+        [TYPE_KEY]: "dropbox-fs",
+
         /**
          * Read a directory and list all the files and folders inside
          * 


### PR DESCRIPTION
Add a type key to the API adapter for recognition in downstream libraries (like any-fs). This will help with overcoming limitations and fragility in detecting what parameters each function supports.