### PR TITLE
Add an option for read-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,25 @@ dfs.readdir('/Public', (err, result) => {
 
 You can also pass in a `client` option if you’re using your own `dropbox` module instead of the `apiKey`.
 
+If you'd like some peace of mind then there's a read-only option too:
+
+``` js
+const dfs = require('dropbox-fs/readonly')({
+    apiKey: 'DROPBOX_API_KEY_HERE'
+});
+
+// Methods that might change data now return an error without performing any action:
+// - mkdir
+// - rename
+// - rmdir
+// - unlink
+// - writeFile
+
+dfs.unlink('/Public', (err) => {
+    console.log(err); // Message saying `unlink` is not supported in read-only
+});
+```
+
 ## API
 
 This module exposes the following methods:

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "codecov": "^1.0.1",
     "mocha": "^3.1.2",
     "nyc": "^8.3.1",
+    "proxyquire": "^1.8.0",
+    "sinon": "^4.2.2",
     "uuid": "^2.0.3"
   },
   "dependencies": {

--- a/src/readonly.js
+++ b/src/readonly.js
@@ -1,0 +1,36 @@
+import normalDropboxFS from './index';
+
+// List of API methods that should be prevented in read-only mode
+const dangerousMethods = [
+    'mkdir',
+    'rename',
+    'rmdir',
+    'unlink',
+    'writeFile',
+];
+
+/**
+ * Create a read-only fs-like API for Dropbox
+ * 
+ * @param {{
+ *  apiKey: String,
+ *  client: Dropbox,
+ * }} Configuration object
+ * @returns {Object}
+ */
+export default ({ client, apiKey }) => {
+
+    const api = normalDropboxFS({ client, apiKey });
+
+    const returnError = (method) => (...methodArgs) => {
+        const cb = methodArgs[methodArgs.length - 1];
+        cb(`${method} is not supported in read-only mode`);
+    };
+
+    // Replace dangerous methods with safe ones
+    dangerousMethods.forEach(method => {
+        api[method] = returnError(method);
+    });
+
+    return api;
+};

--- a/test/readonly.test.js
+++ b/test/readonly.test.js
@@ -1,0 +1,95 @@
+import assert from 'assert';
+import proxyquire from 'proxyquire';
+import { spy, stub } from 'sinon';
+
+// Use proxyquire to inject our own stub FS factory so we don't have to hit Dropbox
+const fsFactory = stub();
+const readonly = proxyquire('../src/readonly', {
+    './index': fsFactory,
+});
+
+describe.only('readonly', function() {
+
+    describe('#ctor', function() {
+
+        beforeEach(() => fsFactory.returns({}));
+        afterEach(() => fsFactory.reset());
+
+        it('passes on `apiKey`', function() {
+            const apiKey = 'dummy';
+            readonly({ apiKey });
+            assert(fsFactory.alwaysCalledWithMatch({ apiKey }));
+        });
+
+        it('passes on `client`', function() {
+            const client = {};
+            readonly({ client });
+            assert(fsFactory.alwaysCalledWithMatch({ client }));
+        });
+
+    });
+
+    describeSafeMethod('readdir', 'dummypath');
+    describeSafeMethod('readFile', 'dummypath');
+    describeSafeMethod('stat', 'dummypath');
+
+    function describeSafeMethod (name, ...args) {
+        describe(`#${name}`, () => {
+
+            // Stub out the corresponding method on the normal API
+            const fsMethod = spy();
+            beforeEach(() => fsMethod.resetHistory());
+
+            beforeEach(() => fsFactory.returns({ [name]: fsMethod }));
+            afterEach(() => fsFactory.reset());
+
+            it('makes call to fs', () => {
+                const readonlyFs = readonly({ client: {} });
+
+                readonlyFs[name](...args, noopCallback);
+
+                assert(fsMethod.alwaysCalledWithExactly(...args, noopCallback));
+            });
+
+        });
+    }
+
+    describeDangerousMethod('mkdir', 'dummypath');
+    describeDangerousMethod('rename', 'dummypath', 'dummypath');
+    describeDangerousMethod('rmdir', 'dummypath');
+    describeDangerousMethod('unlink', 'dummypath');
+    describeDangerousMethod('writeFile', 'dummypath', null);
+
+    function describeDangerousMethod (name, ...args) {
+        describe(`#${name}`, () => {
+
+            // Stub out the corresponding method on the normal API
+            const fsMethod = spy();
+            beforeEach(() => fsMethod.resetHistory());
+
+            beforeEach(() => fsFactory.returns({ [name]: fsMethod }));
+            afterEach(() => fsFactory.reset());
+
+            it('does not call fs', () => {
+                const readonlyFs = readonly({ client: {} });
+
+                readonlyFs[name](...args, noopCallback);
+
+                assert.equal(fsMethod.called, false);
+            });
+
+            it('returns an error', () => {
+                const readonlyFs = readonly({ client: {} });
+
+                const callback = spy();
+                readonlyFs[name](...args, callback);
+
+                assert(callback.alwaysCalledWithExactly(`${name} is not supported in read-only mode`));
+            });
+
+        });
+    }
+
+});
+
+const noopCallback = () => {};

--- a/test/readonly.test.js
+++ b/test/readonly.test.js
@@ -8,7 +8,7 @@ const readonly = proxyquire('../src/readonly', {
     './index': fsFactory,
 });
 
-describe.only('readonly', function() {
+describe('readonly', function() {
 
     describe('#ctor', function() {
 


### PR DESCRIPTION
This wraps the standard FS but ensures that any methods that might change data are replaced with a noop version returning an error.